### PR TITLE
fixed steering angle reference

### DIFF
--- a/Workshops/2019-reInvent/Lab_200_AIM207/Readme.md
+++ b/Workshops/2019-reInvent/Lab_200_AIM207/Readme.md
@@ -202,7 +202,7 @@ The following list contains the variables you can use in your reward function. N
 			"objects_speed": [float, ],            # list of the objects' speeds in meters per second.
 			"progress": float,                     # percentage of track completed
 			"speed": float,                        # agent's speed in meters per second (m/s)
-			"steering": float,                     # agent's steering angle in degrees
+			"steering_angle": float,               # agent's steering angle in degrees
 			"steps": int,                          # number steps completed
 			"track_length": float,                 # track length in meters.
 			"track_width": float,                  # width of the track


### PR DESCRIPTION
fixed parameter reference

*Issue #, if available:*

*Description of changes:*  params["steering"] does not exist, used other examples in readme to find should be steering_angle


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
